### PR TITLE
Add Travis-CI integration and configuration settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: php
+
+sudo: false
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+php:
+ - 5.6
+ - 7.0
+
+env:
+ global:
+  - MOODLE_BRANCH=MOODLE_32_STABLE
+ matrix:
+  - DB=mysqli
+
+before_install:
+  - phpenv config-rm xdebug.ini
+  - cd ../..
+  - composer selfupdate
+  - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^1
+  - export PATH="$(cd ci/bin; pwd):$(cd ci/vendor/bin; pwd):$PATH"
+
+install:
+  - moodle-plugin-ci install
+
+script:
+  - moodle-plugin-ci phplint
+  - moodle-plugin-ci phpcpd
+  - moodle-plugin-ci phpmd
+  - moodle-plugin-ci codechecker
+  - moodle-plugin-ci csslint
+  - moodle-plugin-ci shifter
+  - moodle-plugin-ci jshint
+  - moodle-plugin-ci validate
+  - moodle-plugin-ci phpunit
+  - moodle-plugin-ci behat

--- a/block_grades_at_a_glance.php
+++ b/block_grades_at_a_glance.php
@@ -1,4 +1,18 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
  * Adam Zapletal
@@ -6,83 +20,130 @@
  * Louisiana State University
  **/
 
+defined('MOODLE_INTERNAL') || die();
+
 require_once($CFG->dirroot . '/blocks/grades_at_a_glance/lib.php');
 
 class block_grades_at_a_glance extends block_list {
-    function init() {
+    /**
+     * Core function used to initialize the block.
+     */
+    public function init() {
         $this->title = get_string('pluginname', 'block_grades_at_a_glance');
     }
 
-    function applicable_formats() {
+    /**
+     * Core function, specifies where the block can be used.
+     * @return array
+     */
+    public function applicable_formats() {
         return array('site' => true, 'my' => true, 'course' => false);
     }
 
-    function get_content() {
+    /**
+     * Used to generate the content for the block.
+     * @return string
+     */
+    public function get_content() {
         if ($this->content !== null) {
             return $this->content;
         }
 
-        global $CFG;
-        global $USER;
+        global $CFG, $USER;
 
-        $this->content = new stdClass;
+        // Load admin defaults.
+        $blockconfig = get_config('block_grades_at_a_glance');
+
+        // Set default values.
+        $maxcourses = $blockconfig->defaultmaxcourses;
+        $gradeformat = $blockconfig->defaultgradeformat;
+        $sortorder = $blockconfig->defaultsortorder;
+
+        if (empty($this->config)) {
+            /*
+             * If this is empty, we'll make it an object and create the properties we're expecting
+             * it to have later, giving those properties the admin default values. This prevents
+             * us having to do individual checks for the existence of these properties later.
+             *
+             * This only happens if the user hasn't configured their instance of this block, yet.
+             */
+            $this->config = new stdClass();
+            $this->config->maxcourses = $maxcourses;
+            $this->config->gradeformat = $gradeformat;
+            $this->config->sortorder = $sortorder;
+        }
+
+        $this->content = new stdClass();
 
         $this->content->icons = array();
         $this->content->footer = '';
 
-        $gradebook_roles = explode(',', $CFG->gradebookroles);
+        $gradebookroles = explode(',', $CFG->gradebookroles);
 
-        $no_courses_str = get_string('no_courses', 'block_grades_at_a_glance');
+        // If the user has configured their instance of this block, we'll load them now.
+        $maxcourses = $this->config->maxcourses;
+        $gradeformat = $this->config->gradeformat;
+        $sortorder = $this->config->sortorder;
 
-        // Return early if this user is enrolled in zero courses
-        if (!$courses = enrol_get_my_courses($fields = 'showgrades')) {
-            $this->content->items = array($no_courses_str);
+        $courses = gaag_get_all_courses($maxcourses, $sortorder);
+
+        $noenrollments = get_string('no_courses', 'block_grades_at_a_glance');
+
+        // Return early if this user is enrolled in zero courses.
+        if (count($courses['sortedcourses']) == 0) {
+            $this->content->items = array($noenrollments);
 
             return $this->content;
         }
 
+        $linkcommon = '/grade/report/user/index.php';
 
-        $link_common = '/grade/report/user/index.php';
+        foreach ($courses['sortedcourses'] as $course) {
+            $coursecontext = context_course::instance($course->id);
+            $rolesincourse = get_user_roles($coursecontext);
 
-        foreach ($courses as $course) {
-            $course_context = context_course::instance($course->id);
-            $roles_in_course = get_user_roles($course_context);
-
-            $id = $course->id;
-
+            $courseid = $course->id;
             $coursename = gaag_get_shortname($course->shortname);
+            $showgrades = $course->showgrades;
 
-            foreach ($roles_in_course as $role_in_course) {
-                if (in_array($role_in_course->roleid, $gradebook_roles)) {
-                    $url = new moodle_url($link_common, array('id' => $id));
+            foreach ($rolesincourse as $roleincourse) {
+                if (in_array($roleincourse->roleid, $gradebookroles)) {
+                    $item = '';
+                    $content = '';
 
-                    $content = html_writer::link($url, $coursename);
+                    $url = new moodle_url($linkcommon, array('id' => $courseid));
+                    $link = html_writer::link($url, $coursename);
                     $params = array('class' => 'gaag_course');
 
-                    $left_part = html_writer::tag('span', $content, $params);
+                    $leftpart = html_writer::tag('span', $link, $params);
 
-                    $content = gaag_get_grade_for_course($id, $USER->id);
+                    $grade = gaag_get_grade_for_course($courseid, $USER->id, $gradeformat);
                     $params = array('class' => 'gaag_grade');
 
-                    $right_part = html_writer::tag('span', $content, $params);
+                    if ($showgrades == 1) {
+                        $rightpart = html_writer::tag('span', $grade, $params);
+                    } else {
+                        $rightpart = html_writer::tag('span', '-', $params);
+                    }
 
-                    $right_part = $course->showgrades == 1 ? html_writer::tag('span', $content, $params) : html_writer::tag('span', '-', $params);
+                    $content = $leftpart . $rightpart;
+                    $item .= html_writer::tag('p', $content);
 
-                    $content = $left_part . $right_part;
-
-                    $this->content->items[] = html_writer::tag('p', $content);
+                    $this->content->items[] = $item;
                     break;
                 }
             }
         }
 
-/*      Hide this block completely from instructors.
-        // User is only in non-gradable roles in the courses they are enrolled in
-        if (!count($this->content->items)) {
-            $this->content->items = array($no_courses_str);
-        }
-*/
-
         return $this->content;
+    }
+
+    /**
+     * Allow the block to have a configuration page
+     *
+     * @return boolean
+     */
+    public function has_config() {
+        return true;
     }
 }

--- a/db/access.php
+++ b/db/access.php
@@ -1,4 +1,18 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 defined('MOODLE_INTERNAL') || die();
 
@@ -12,15 +26,14 @@ $capabilities = array(
 
         'clonepermissionsfrom' => 'moodle/site:manageblocks'
     ),
-    
+
     'block/grades_at_a_glance:myaddinstance' => array(
         'captype' => 'read',
         'contextlevel' => CONTEXT_SYSTEM,
         'archetypes' => array(
             'student' => CAP_ALLOW
         ),
- 
+
         'clonepermissionsfrom' => 'moodle/my:manageblocks'
     ),
 );
-?>

--- a/edit_form.php
+++ b/edit_form.php
@@ -1,0 +1,107 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Defines the form for editing Grades at a Glance block instances.
+ *
+ * @package    block_grades_at_a_glance
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once($CFG->dirroot.'/blocks/grades_at_a_glance/lib.php');
+
+class block_grades_at_a_glance_edit_form extends block_edit_form {
+    /**
+     * The definition of the fields to use.
+     *
+     * @param MoodleQuickForm $mform
+     */
+    protected function specific_definition($mform) {
+        global $DB, $USER;
+
+        // Load admin defaults.
+        $blockconfig = get_config('block_grades_at_a_glance');
+
+        // Attempt to get the user's block configuration.
+        $blockinstanceid = required_param('bui_editid', PARAM_INT);
+        $sql = 'SELECT context.instanceid, instance.configdata
+                FROM {context} context
+                JOIN {block_instances} instance
+                ON instance.parentcontextid=context.id
+                WHERE instance.id=?';
+        $blockinstancerecord = $DB->get_record_sql($sql, array($blockinstanceid));
+
+        if ($blockinstancerecord->instanceid == $USER->id && !empty($blockinstancerecord->configdata)) {
+            $configdata = unserialize(base64_decode($blockinstancerecord->configdata));
+            $maxcourses = $configdata->maxcourses;
+            $sortorder = $configdata->sortorder;
+            $gradeformat = $configdata->gradeformat;
+        } else {
+            // If the user doesn't own this block instance or they haven't configured their instance,
+            // then we'll just use the admin defaults.
+            $maxcourses = $blockconfig->defaultmaxcourses;
+            $sortorder = $blockconfig->defaultsortorder;
+            $gradeformat = $blockconfig->defaultgradeformat;
+        }
+
+        $mform->addElement('header', 'configheader', get_string('blocksettings', 'block'));
+
+        $courses = gaag_get_all_courses($maxcourses, $sortorder);
+        $numberofcourses = array('0' => get_string('all'));
+        for ($counter = 1; $counter <= $courses['totalcourses']; $counter++) {
+            $numberofcourses[$counter] = $counter;
+        }
+
+        $mform->addElement('select', 'config_maxcourses', get_string('maxcourses', 'block_grades_at_a_glance'),
+            $numberofcourses);
+
+        if ($blockconfig->defaultmaxcourses_locked) {
+            $mform->freeze('config_maxcourses');
+        }
+
+        $gradeformatoptions = array(GRADE_DISPLAY_TYPE_REAL              => get_string('real', 'grades'),
+                                    GRADE_DISPLAY_TYPE_REAL_PERCENTAGE   => get_string('realpercentage', 'grades'),
+                                    GRADE_DISPLAY_TYPE_REAL_LETTER       => get_string('realletter', 'grades'),
+                                    GRADE_DISPLAY_TYPE_PERCENTAGE        => get_string('percentage', 'grades'),
+                                    GRADE_DISPLAY_TYPE_PERCENTAGE_REAL   => get_string('percentagereal', 'grades'),
+                                    GRADE_DISPLAY_TYPE_PERCENTAGE_LETTER => get_string('percentageletter', 'grades'),
+                                    GRADE_DISPLAY_TYPE_LETTER            => get_string('letter', 'grades'),
+                                    GRADE_DISPLAY_TYPE_LETTER_REAL       => get_string('letterreal', 'grades'),
+                                    GRADE_DISPLAY_TYPE_LETTER_PERCENTAGE => get_string('letterpercentage', 'grades'));
+        $mform->addElement('select', 'config_gradeformat', get_string('gradeformat', 'block_grades_at_a_glance'),
+            $gradeformatoptions);
+        $mform->setDefault('config_gradeformat', $gradeformat);
+
+        if ($blockconfig->defaultgradeformat_locked) {
+            $mform->freeze('config_gradeformat');
+        }
+
+        $sortorderinput = $mform->createElement('advcheckbox', 'config_sortorder',
+            get_string('sortorder', 'block_grades_at_a_glance'));
+
+        if ($sortorder) {
+            $sortorderinput->setChecked(true);
+        }
+
+        $mform->addElement($sortorderinput);
+
+        if ($blockconfig->defaultsortorder_locked) {
+            $mform->freeze('config_sortorder');
+        }
+    }
+}

--- a/lang/en/block_grades_at_a_glance.php
+++ b/lang/en/block_grades_at_a_glance.php
@@ -1,7 +1,37 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-$string['pluginname'] = 'Grades at a Glance';
+/**
+ * Strings for component 'block_grades_at_a_glance'
+ *
+ * @package    block_grades_at_a_glance
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['defaultgradeformat'] = 'Default grade format';
+$string['defaultgradeformatdesc'] = 'How the grades should be formatted when displayed to students.';
+$string['defaultmaxcourses'] = 'Default maximum courses';
+$string['defaultmaxcoursesdesc'] = 'Maximum courses which should be displayed on course overview block, 0 will show all courses';
+$string['defaultsortorder'] = 'Use Course Overview sort';
+$string['defaultsortorderdesc'] = "Should the courses be sorted per the user's Course Overview sort order?";
+$string['gradeformat'] = 'Grade format';
+$string['grades_at_a_glance:myaddinstance'] = 'Add Grades Central Block to the My page';
+$string['grades_at_a_glance:addinstance'] = 'Add Grades Central Block';
 $string['hidden'] = 'Hidden';
+$string['maxcourses'] = 'Number of courses to display: ';
 $string['no_courses'] = 'No courses as student';
-$string['grades_at_a_glance:myaddinstance'] = 'Add Grades at a Glance Block to the My page';
-$string['grades_at_a_glance:addinstance'] = 'Add Grades at a Glance Block';
+$string['pluginname'] = 'Grades at a Glance';
+$string['sortorder'] = 'Use Course Overview sort order?';

--- a/lib.php
+++ b/lib.php
@@ -1,42 +1,213 @@
 <?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Strings for component 'block_grades_at_a_glance'
+ *
+ * @package    block_grades_at_a_glance
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
 
 require_once($CFG->libdir . '/grade/grade_item.php');
 require_once($CFG->libdir . '/grade/grade_grade.php');
 require_once($CFG->libdir . '/gradelib.php');
 
-// Returns the formatted course total item value give a userid and a course id
-function gaag_get_grade_for_course($courseid, $userid) {
-    $course_total_item = grade_item::fetch_course_item($courseid);
+/**
+ * Gets the grade for the specified user and specified course, then
+ * formats the grade according to either the user's preference or
+ * the admin default.
+ *
+ * @param int $courseid The id of the course to get grades for
+ * @param int $userid The id of the user whose grades we want
+ * @param int $gradeformat How the grade should be formatted
+ *
+ * @return string The formatted grade, ready for display.
+ */
+function gaag_get_grade_for_course($courseid, $userid, $gradeformat) {
+    $finalgrade = '-';
+    $coursetotalobj = grade_item::fetch_course_item($courseid);
 
-    if (!$course_total_item) {
-        return '-';
-    }
+    if ($coursetotalobj) {
+        if ($coursetotalobj->hidden) {
+            $finalgrade = get_string('hidden', 'block_grades_at_a_glance');
+        } else {
+            $gradeparams = array(
+                'itemid' => $coursetotalobj->id,
+                'userid' => $userid
+            );
 
-    if ($course_total_item->hidden) {
-        return get_string('hidden', 'block_grades_at_a_glance');
-    }
+            $usergrade = new grade_grade($gradeparams);
 
-    $grade_grade_params = array(
-        'itemid' => $course_total_item->id,
-        'userid' => $userid
-    );
-
-    $user_grade_grade = new grade_grade($grade_grade_params);
-
-    if (!$user_grade_grade->finalgrade) {
-        $finalgrade = '-';
-    } else {
-        $finalgrade = grade_format_gradevalue(
-            $user_grade_grade->finalgrade,
-            $course_total_item, true
-        );
+            if ($usergrade->finalgrade) {
+                $finalgrade = grade_format_gradevalue(
+                    $usergrade->finalgrade,
+                    $coursetotalobj, true, $gradeformat
+                );
+            }
+        }
     }
 
     return $finalgrade;
 }
 
+/**
+ * Trims the course's short name at the word "for" and returns
+ * everything before the word "for".
+ *
+ * @param string $shortname The entire short name of the course.
+ *
+ * @return string The course's short name trimmed at the word "for"
+ */
 function gaag_get_shortname($shortname) {
     $split = preg_split('/\s+for\s+/', $shortname);
 
     return $split[0];
+}
+
+/**
+ * Using the user's preferred sort order, extracts those courses from
+ * $courses and puts them into $sortedcourses, up to the maximum as
+ * defined by $maxcourses.
+ *
+ * @param array $courses Array of courses in which the user is enrolled as a student
+ * @param int $maxcourses The maximum number of courses to display
+ * @param array $sortedcourses Array of courses sorted by the user's preference
+ *
+ * @return array The sorted courses
+ */
+function gaag_get_sorted_courses($courses, $maxcourses, $sortedcourses) {
+    $value = get_user_preferences('course_overview_course_sortorder');
+    $sortorder = explode(',', $value);
+    $counter = 0;
+
+    foreach ($sortorder as $sortid) {
+        if (($counter >= $maxcourses) && ($maxcourses != 0)) {
+            break;
+        }
+
+        // Make sure user is still enroled.
+        if (isset($courses[$sortid])) {
+            $sortedcourses[$sortid] = $courses[$sortid];
+            $counter++;
+        }
+    }
+
+    return $sortedcourses;
+}
+
+/**
+ * Adds a number of courses, up to a maximum of $maxcourses, to $sortedcourses
+ * from $courses. If the course is already in $sortedcourses, it will not be
+ * added a second time.
+ *
+ * @param array $courses Array of courses in which the user is enrolled as a student
+ * @param int $maxcourses The maximum number of courses to display
+ * @param array $sortedcourses Array of courses sorted by the user's preference, if any
+ *
+ * return array Array of courses
+ */
+function gaag_get_unsorted_courses($courses, $maxcourses, $sortedcourses) {
+    $counter = count($sortedcourses);
+
+    // Append unsorted courses if limit allows.
+    foreach ($courses as $course) {
+        if (($counter >= $maxcourses) && ($maxcourses != 0)) {
+            break;
+        }
+
+        if (!array_key_exists($course->id, $sortedcourses)) {
+            $sortedcourses[$course->id] = $course;
+            $counter++;
+        }
+    }
+
+    return $sortedcourses;
+}
+
+/**
+ * Gets any remote courses the user is enrolled in as a student and adds them
+ * to the $courses array.
+ *
+ * @param array $courses Array of courses the user is enrolled in as a student, if any
+ *
+ * @return array Array of courses
+ */
+function gaag_append_remote_courses($courses) {
+    // Get remote courses.
+    $remotecourses = array();
+
+    if (is_enabled_auth('mnet')) {
+        $remotecourses = get_my_remotecourses();
+
+        // Remote courses will have -ve remoteid as key, so it can be differentiated from normal courses.
+        foreach ($remotecourses as $val) {
+            $remoteid = $val->remoteid * -1;
+            $val->id = $remoteid;
+            $courses[$remoteid] = $val;
+        }
+    }
+
+    return $courses;
+}
+
+/**
+ * Removes the site course from the $courses array.
+ *
+ * @param array $courses The array of courses
+ *
+ * @return array The array of courses, without the site course
+ */
+function gaag_remove_site_courses($courses) {
+    $site = get_site();
+
+    if (array_key_exists($site->id, $courses)) {
+        unset($courses[$site->id]);
+    }
+
+    return $courses;
+}
+
+/**
+ * Returns a multi-dimensional associative array containing an array of courses and the total number
+ * of courses in which the user is enrolled as a student.
+ *
+ * @param int $maxcourses Maximum number of courses to display
+ * @param int $courseoverviewsort Whether to sort courses using the user's preference from Course
+ *      Overview block; 1 if sorted by Course Overview preference, 0 otherwise
+ *
+ * @return array Multi-dimensional associative array where the first element is an array of courses
+ *      and the second element is an integer representing the total number of courses in which the
+ *      user is enrolled
+ */
+function gaag_get_all_courses($maxcourses, $courseoverviewsort) {
+    $sortedcourses = array();
+
+    $courses = enrol_get_my_courses('showgrades', 'id DESC');
+
+    $courses = gaag_remove_site_courses($courses);
+    $courses = gaag_append_remote_courses($courses);
+
+    // Get courses sorted by Course Overview sort order, if the user has selected (or admin has forced) this.
+    if ($courseoverviewsort) {
+        $sortedcourses = gaag_get_sorted_courses($courses, $maxcourses, $sortedcourses);
+    }
+
+    $sortedcourses = gaag_get_unsorted_courses($courses, $maxcourses, $sortedcourses);
+
+    return array('sortedcourses' => $sortedcourses, 'totalcourses' => count($courses));
 }

--- a/settings.php
+++ b/settings.php
@@ -1,0 +1,56 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * course_overview block settings
+ *
+ * @package    block_grades_at_a_glance
+ * @copyright  2012 Adam Olley <adam.olley@netspot.com.au>
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+defined('MOODLE_INTERNAL') || die;
+
+// Default maximum courses to display.
+$setting = new admin_setting_configtext('block_grades_at_a_glance/defaultmaxcourses',
+    new lang_string('defaultmaxcourses', 'block_grades_at_a_glance'),
+    new lang_string('defaultmaxcoursesdesc', 'block_grades_at_a_glance'), 10, PARAM_INT);
+$setting->set_locked_flag_options(admin_setting_flag::ENABLED, false);
+$settings->add($setting);
+
+// Default grade format.
+$gradeformatoptions = array(GRADE_DISPLAY_TYPE_REAL       => get_string('real', 'grades'),
+                            GRADE_DISPLAY_TYPE_REAL_PERCENTAGE => get_string('realpercentage', 'grades'),
+                            GRADE_DISPLAY_TYPE_REAL_LETTER => get_string('realletter', 'grades'),
+                            GRADE_DISPLAY_TYPE_PERCENTAGE => get_string('percentage', 'grades'),
+                            GRADE_DISPLAY_TYPE_PERCENTAGE_REAL => get_string('percentagereal', 'grades'),
+                            GRADE_DISPLAY_TYPE_PERCENTAGE_LETTER => get_string('percentageletter', 'grades'),
+                            GRADE_DISPLAY_TYPE_LETTER     => get_string('letter', 'grades'),
+                            GRADE_DISPLAY_TYPE_LETTER_REAL => get_string('letterreal', 'grades'),
+                            GRADE_DISPLAY_TYPE_LETTER_PERCENTAGE => get_string('letterpercentage', 'grades'));
+
+$setting = new admin_setting_configselect('block_grades_at_a_glance/defaultgradeformat',
+    new lang_string('defaultgradeformat', 'block_grades_at_a_glance'),
+    new lang_string('defaultgradeformatdesc', 'block_grades_at_a_glance'), GRADE_DISPLAY_TYPE_LETTER_PERCENTAGE,
+    $gradeformatoptions);
+$setting->set_locked_flag_options(admin_setting_flag::ENABLED, false);
+$settings->add($setting);
+
+// Default use Course Overview sort order.
+$setting = new admin_setting_configcheckbox('block_grades_at_a_glance/defaultsortorder',
+    new lang_string('defaultsortorder', 'block_grades_at_a_glance'),
+    new lang_string('defaultsortorderdesc', 'block_grades_at_a_glance'), 0, 1);
+$setting->set_locked_flag_options(admin_setting_flag::ENABLED, false);
+$settings->add($setting);

--- a/styles.css
+++ b/styles.css
@@ -1,11 +1,11 @@
 .block_grades_at_a_glance p {
+    clear: both;
+    font-size: 74%;
+    height: 2.5em;
     margin: 0;
     padding: 0;
-    clear: both;
     text-align: right;
-    font-size: 74%;
     vertical-align: middle;
-    height: 2.5em;
 }
 
 .block_grades_at_a_glance span.gaag_course {
@@ -15,8 +15,8 @@
 }
 
 .block_grades_at_a_glance span.gaag_grade {
+    float: right;
     font-weight: bold;
     margin-top: .25em;
     padding-left: .50em;
-    float: right;
 }

--- a/version.php
+++ b/version.php
@@ -1,5 +1,4 @@
 <?php
-
 // This file is part of Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
@@ -15,5 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
-$plugin->version = 2013062708;
+defined('MOODLE_INTERNAL') || die();
+
 $plugin->component = 'block_grades_at_a_glance';
+$plugin->version = 2017041300;
+$plugin->requires = 2016120500;
+$plugin->maturity = MATURITY_STABLE;
+$plugin->release = 'v2.0.0';
+$plugin->dependencies = array('block_course_overview' => ANY_VERSION);


### PR DESCRIPTION
This first commit adds Travis-CI integration. I added that to make sure my own code met Moodle standards as closely as possible. Adding this required me to change some of the existing code, especially variable names with underscores in them.

The second commit adds both administrator/site-wide configuration and per-user/instance configuration settings. Specifically, it enables users to determine how many courses they want to display, how grades should be displayed, and whether to sort the displayed courses using the sort order from the Course Overview block or not (in which case the courses are sorted descending by course id). Administrators are able to lock each of these settings, preventing users from making their own selections. Grade format defaults to Letter (Percentage), and sort order defaults to "descending by course id" so as to not integrate this block too tightly with the Course Overview block. I've also added a dependency on the Course Overview block.